### PR TITLE
Feat: manage posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Next Firestore Content Management System
 
-This repo is an example of using Firestore (www.firebase.com) as a Content Management System
+This repo is an example of using Firebase v9 (www.firebase.com) as a Content Management System with NextJS, Typescript and TailwindCSS
 
 ## Quickstart
 

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { IPost } from '../interfaces/'
+
+interface IProps {
+  post: IPost
+  onClick: (post: IPost) => void
+}
+
+const Post = ({ post, onClick }: IProps) => {
+  return (
+    <div className="py-8 flex flex-wrap md:flex-nowrap">
+      <div className="md:flex-grow" onClick={() => onClick(post)}>
+        <h2 className="text-2xl font-medium text-gray-900 title-font mb-2">
+          {post.title}
+        </h2>
+        <p className="leading-relaxed">{post.description}</p>
+
+        <Link href={`/posts/${post.id}`} passHref>
+          <a className="text-indigo-500 inline-flex items-center mt-4">
+            Learn More
+            <svg
+              className="w-4 h-4 ml-2"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M5 12h14"></path>
+              <path d="M12 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default Post

--- a/components/forms/PostForm.tsx
+++ b/components/forms/PostForm.tsx
@@ -1,5 +1,81 @@
-const PostForm = () => {
-  return <div>Post form</div>
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import { IPost, IFormInputs } from '../../interfaces'
+
+type FormProps = {
+  initialValues: { post?: IPost | null } | null
+  onSave: (data: IFormInputs) => void
 }
 
+const schema = yup
+  .object({
+    title: yup.string().required(),
+    description: yup.string().required(),
+  })
+  .required()
+
+const PostForm = (props: FormProps) => {
+  // const { post } = props.initialValues
+  // console.log(post)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    setValue,
+  } = useForm<IFormInputs>({
+    mode: 'onChange',
+    resolver: yupResolver(schema),
+    // defaultValues: {
+    //   title: props.initialValues?.post?.title,
+    //   description: props.initialValues?.post?.description,
+    // },
+  })
+  const onSubmit = (data: IFormInputs) => {
+    let formData = data
+    if (props.initialValues?.post?.id) {
+      formData.id = props.initialValues?.post.id
+    }
+    props.onSave(data)
+    reset()
+  }
+
+  React.useEffect(() => {
+    console.log(props.initialValues)
+    if (props.initialValues?.post) {
+      setValue('title', props.initialValues.post?.title)
+      setValue('description', props.initialValues.post?.description)
+    }
+  }, [props.initialValues])
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label htmlFor="title" className="leading-7 text-sm text-gray-600">
+        Title
+      </label>
+      <input
+        {...register('title')}
+        className="w-full bg-white rounded border border-gray-300 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out"
+      />
+      <p className="text-sm text-red-500">{errors.title?.message}</p>
+      <label htmlFor="description" className="leading-7 text-sm text-gray-600">
+        Description
+      </label>
+      <textarea
+        {...register('description')}
+        className="w-full bg-white rounded border border-gray-300 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out"
+      />
+      <p className="text-sm text-red-500">{errors.description?.message}</p>
+
+      <button
+        type="submit"
+        className="mt-4 px-4 py-3  leading-6 text-base rounded-md border border-transparent text-white focus:outline-none bg-blue-500 text-blue-100 hover:text-white focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer inline-flex items-center w-full justify-center items-center font-medium focus:outline-none"
+      >
+        Save
+      </button>
+    </form>
+  )
+}
 export default PostForm

--- a/interfaces/index.tsx
+++ b/interfaces/index.tsx
@@ -34,6 +34,12 @@ export interface IProfile {
   skills?: { label: string; value: string }[]
 }
 
+export interface IFormInputs {
+  id?: string
+  title: string
+  description: string
+}
+
 export interface IPost {
   id: string
   title: string

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^2.8.5",
     "firebase": "^9.6.2",
     "firebase-admin": "^10.0.1",
     "next": "12.0.7",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-hook-form": "^7.22.5",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",

--- a/pages/api/db.ts
+++ b/pages/api/db.ts
@@ -15,7 +15,7 @@ import {
   DocumentData,
   // serverTimestamp,
 } from 'firebase/firestore'
-import { IPost } from '../../interfaces'
+import { IFormInputs, IPost } from '../../interfaces'
 
 type UserData = {
   email: string
@@ -152,12 +152,31 @@ export const getPost = async (postId?: string) =>
     }
   }
 
-export const addPost = async (data: IPost) =>
+export const addPost = async (data: IFormInputs) =>
   // req: NextApiRequest,
   // res: NextApiResponse<Data>
   {
     try {
       const docRef = await addDoc(collection(firestore, 'posts'), {
+        ...data,
+        createdAt: new Date().toLocaleDateString(),
+      })
+      console.log('Post created with id: ', docRef)
+    } catch (e) {
+      console.error('Error adding document: ', e)
+    }
+  }
+
+export const updatePost = async (data: IFormInputs) =>
+  // req: NextApiRequest,
+  // res: NextApiResponse<Data>
+  {
+    if (!data.id) {
+      return
+    }
+
+    try {
+      const docRef = await updateDoc(doc(firestore, 'posts', data.id), {
         ...data,
       })
       console.log('Post created with id: ', docRef)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,12 @@
 import type { NextPage } from 'next'
-import Link from 'next/link'
+// import Link from 'next/link'
+import * as React from 'react'
+import { useRouter } from 'next/router'
 import { InferGetServerSidePropsType, GetServerSideProps } from 'next'
-import { getPosts } from './api/db'
-import { IPost } from '../interfaces/'
+import { getPosts, addPost, updatePost } from './api/db'
+import { IPost, IFormInputs } from '../interfaces/'
+import PostForm from '@components/forms/PostForm'
+import Post from '@components/Post'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { res } = context
@@ -18,35 +22,39 @@ const Home: NextPage = ({
   posts,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   // console.log(posts)
+  const router = useRouter()
+
+  const [currentPost, setCurrentPost] = React.useState<IPost | null>(null)
+
+  const handlePost = (data: IFormInputs) => {
+    // console.log(data)
+    if (data.id) {
+      updatePost(data)
+    } else {
+      addPost(data)
+    }
+
+    refreshData()
+  }
+
+  const handleClickPost = (data: IPost) => {
+    console.log(data)
+    setCurrentPost(data)
+  }
+
+  const refreshData = () => {
+    //Hacky method of refreshing the page using server side data
+    router.replace(router.asPath)
+  }
   return (
     <section className="text-gray-600 body-font">
       <div className="container px-5 py-24 mx-auto">
+        <PostForm
+          onSave={handlePost}
+          initialValues={currentPost ? { post: currentPost } : null}
+        />
         {posts.map((post: IPost) => (
-          <div key={post.id} className="py-8 flex flex-wrap md:flex-nowrap">
-            <div className="md:flex-grow">
-              <h2 className="text-2xl font-medium text-gray-900 title-font mb-2">
-                {post.title}
-              </h2>
-              <p className="leading-relaxed">{post.description}</p>
-              <Link href={`/posts/${post.id}`} passHref>
-                <a className="text-indigo-500 inline-flex items-center mt-4">
-                  Learn More
-                  <svg
-                    className="w-4 h-4 ml-2"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    fill="none"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M5 12h14"></path>
-                    <path d="M12 5l7 7-7 7"></path>
-                  </svg>
-                </a>
-              </Link>
-            </div>
-          </div>
+          <Post key={post.id} post={post} onClick={handleClickPost} />
         ))}
       </div>
     </section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,7 +57,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.16.3":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -737,6 +737,11 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
   integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
+"@hookform/resolvers@^2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.8.5.tgz#25b902bd40516c1755bc857753283de740560aff"
+  integrity sha512-n7eFm4snsejpfZVH8q2NU7YJbsGhF61IHB0TxgK11nmg08RymEr3KscnbTAZaPd9RaXa3vUPoULgBRN2nVDtMg==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
@@ -1017,6 +1022,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/lodash@^4.14.175":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
 "@types/long@^4.0.0", "@types/long@^4.0.1":
   version "4.0.1"
@@ -3631,6 +3641,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -3686,7 +3701,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3882,6 +3897,11 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.1.23, nanoid@^3.1.30:
   version "3.1.30"
@@ -4394,6 +4414,11 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
+
 proto3-json-serializer@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-0.1.6.tgz#67cf3b8d5f4c8bebfc410698ad3b1ed64da39c7b"
@@ -4524,6 +4549,11 @@ react-dom@17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-hook-form@^7.22.5:
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.22.5.tgz#85a135f3c5ae02ccf73096a03fc14b45607e9baa"
+  integrity sha512-Q2zaeQFXdVQ8l3hcywhltH+Nzj4vo50wMVujHDVN/1Xy9IOaSZJwYBXA2CYTpK6rq41fnXviw3jTLb04c7Gu9Q==
 
 react-is@17.0.2:
   version "17.0.2"
@@ -5249,6 +5279,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -5648,3 +5683,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
This PR is for managing posts from the firestore collection

## Description
This PR incorporates the following changes
- Add dependencies for handling form submissions `react-hook-form` `yup` `@hookform/resolvers`
- Add PostForm component `components/forms/PostForm.tsx`
- Modifies homepage to display PostForm and refresh with updated firestore collection

## Related Issue
N/A

## Motivation and Context
Allows user input to manipulate the contents of the firestore collection

## How Has This Been Tested?
- Manual browser testing

## Screenshots (if appropriate):
N/A